### PR TITLE
update gcloud-sdk to fix metadata server issue

### DIFF
--- a/secret-vault/Cargo.toml
+++ b/secret-vault/Cargo.toml
@@ -33,7 +33,7 @@ tokio = { version = "1", features = ["sync", "tracing", "macros", "rt", "time"] 
 hex = "0.4"
 ring = { version = "0.17", features = ["default", "std"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
-gcloud-sdk = { version = "0.25", optional = true }
+gcloud-sdk = { version = "0.25.2", optional = true }
 aws-config = { version = "1", optional = true }
 aws-smithy-types-convert = { version = "0.60", optional = true, features=["convert-chrono"] }
 aws-sdk-secretsmanager = { version = "1", optional = true }


### PR DESCRIPTION
Updates the gcloud sdk version to fix the issue mentioned in this PR: https://github.com/abdolence/gcloud-sdk-rs/pull/154

Solves the issue opened here: https://github.com/abdolence/secret-vault-rs/issues/100

