### PR TITLE
Add flag to switch between tls-roots and tls-webpki-roots for GCP Cloud

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,8 +1,8 @@
 name: tests & formatting
-on: 
+on:
   push:
   pull_request:
-    types: [opened]  
+    types: [opened]
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -13,4 +13,18 @@ jobs:
           profile: minimal
           toolchain: stable
           components: rustfmt, clippy
-      - run: cargo fmt -- --check && cargo clippy --all-features -- -Dwarnings && cargo test --all-features
+      - name: Run checks
+        run: |
+          # Format check
+          cargo fmt -- --check
+          
+          # Common features for both variants
+          FEATURES="serde,ring-aead-encryption,kms,gcp-secretmanager,gcp-kms,aws,aws-secretmanager,aws-kms-encryption,ahash"
+          
+          # Run checks with gcp-tls-roots
+          cargo clippy --features "$FEATURES,gcp-tls-roots" -- -Dwarnings
+          cargo test --features "$FEATURES,gcp-tls-roots"
+          
+          # Run checks with gcp-tls-webpki
+          cargo clippy --features "$FEATURES,gcp-tls-webpki" -- -Dwarnings
+          cargo test --features "$FEATURES,gcp-tls-webpki"

--- a/README.md
+++ b/README.md
@@ -38,19 +38,50 @@ Library provides the support for the secrets coming to your application from the
 Cargo.toml:
 ```toml
 [dependencies]
-secret-vault = { version = "1.8", features=["..."] }
-secret-vault-type = { version = "0.3" }
+secret-vault = { version = "1.15", features=["..."] }
 ```
 See security consideration below about versioning.
 
 ### Available optional features for Secret Vault:
-- `gcp-secretmanager` for Google Secret Manager support
-- `aws-secretmanager` for Amazon Secret Manager support
-- `ring-aead-encryption` for encryption support using Ring AEAD
-- `gcp-kms-encryption` for Google KMS envelope encryption support
-- `aws-kms-encryption` for Amazon KMS envelope encryption support
-- `serde` for serde serialization support
-- `ahash` for maps and snapshots based on [AHashMap](https://crates.io/crates/ahash)
+
+#### Cloud Provider Features
+**Google Cloud Platform (GCP)**
+- `gcp-secretmanager` - Google Secret Manager support
+- `gcp-kms` - Google Cloud KMS support
+- One of the following TLS implementations is required when using GCP features:
+  - `gcp-tls-roots` - System TLS roots (default)
+  - `gcp-tls-webpki` - WebPKI roots
+
+**Amazon Web Services (AWS)**
+- `aws-secretmanager` - AWS Secrets Manager support
+- `aws-kms-encryption` - AWS KMS envelope encryption support
+
+#### Encryption Features
+- `ring-aead-encryption` - Encryption support using Ring AEAD
+- `kms` - Base KMS support for envelope encryption
+
+#### Utility Features
+- `serde` - Serde serialization support
+- `ahash` - Uses [AHashMap](https://crates.io/crates/ahash) for maps and snapshots
+
+### Feature Flag Examples
+
+For GCP Secret Manager with system TLS roots:
+```toml
+secret-vault = { version = "1.15", features = ["gcp-secretmanager", "gcp-tls-roots"] }
+```
+
+For AWS Secrets Manager with KMS encryption:
+```toml
+secret-vault = { version = "1.15", features = ["aws-secretmanager", "aws-kms-encryption"] }
+```
+
+For GCP Secret Manager with WebPKI and serde support:
+```toml
+secret-vault = { version = "1.15", features = ["gcp-secretmanager", "gcp-tls-webpki", "serde"] }
+```
+
+Note: When using GCP features, you must choose either `gcp-tls-roots` or `gcp-tls-webpki`. These features are mutually exclusive and cannot be enabled simultaneously.
 
 ## Example for GCP with AEAD encryption:
 

--- a/secret-vault/Cargo.toml
+++ b/secret-vault/Cargo.toml
@@ -33,7 +33,7 @@ tokio = { version = "1", features = ["sync", "tracing", "macros", "rt", "time"] 
 hex = "0.4"
 ring = { version = "0.17", features = ["default", "std"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
-gcloud-sdk = { version = "0.26.0", optional = true }
+gcloud-sdk = { version = "0.26.0", default-features = false, optional = true }
 aws-config = { version = "1", optional = true }
 aws-smithy-types-convert = { version = "0.60", optional = true, features=["convert-chrono"] }
 aws-sdk-secretsmanager = { version = "1", optional = true }
@@ -59,9 +59,13 @@ default = []
 serde = ["dep:serde", "chrono/serde", "secret-vault-value/serde"]
 ring-aead-encryption = ["dep:ring", "kms-aead/ring-aead-encryption"]
 kms = ["kms-aead/default"]
-gcp = ["gcloud-sdk"]
-gcp-secretmanager =  ["gcp","gcloud-sdk/google-cloud-secretmanager-v1", "ring-aead-encryption"]
-gcp-kms-encryption = ["gcp", "kms", "gcloud-sdk/google-cloud-kms-v1", "kms-aead/gcp-kms-encryption", "ring-aead-encryption"]
+gcp-base = ["gcloud-sdk"]
+# TLS variants - user can choose one
+gcp-tls-roots = ["gcp-base", "gcloud-sdk/tls-roots"]
+gcp-tls-webpki = ["gcp-base", "gcloud-sdk/tls-webpki-roots"]
+gcp-secretmanager = ["gcp-base", "gcloud-sdk/google-cloud-secretmanager-v1", "ring-aead-encryption"]
+gcp-kms = ["gcp-base", "kms", "gcloud-sdk/google-cloud-kms-v1", "kms-aead/gcp-kms-encryption", "ring-aead-encryption"]
+gcp = ["gcp-tls-roots"]  # Default to tls-roots for backward compatibility
 aws = ["dep:aws-config", "dep:aws-smithy-types-convert"]
 aws-secretmanager = ["aws", "dep:aws-sdk-secretsmanager"]
 aws-kms-encryption = ["aws", "kms", "dep:aws-sdk-kms", "kms-aead/aws-kms-encryption", "ring-aead-encryption"]
@@ -71,12 +75,24 @@ ahash = ["dep:ahash"]
 tag-prefix=""
 
 [package.metadata.docs.rs]
-all-features = true
+all-features = false
+features = [
+    "serde",
+    "ring-aead-encryption",
+    "kms",
+    "gcp-tls-roots",
+    "gcp-secretmanager",
+    "gcp-kms",
+    "aws",
+    "aws-secretmanager",
+    "aws-kms-encryption",
+    "ahash"
+]
 
 [[example]]
 name = "gcp_secret_manager_vault"
 path = "examples/gcp_secret_manager_vault.rs"
-required-features = ["gcp-secretmanager", "ring-aead-encryption"]
+required-features = ["gcp-secretmanager", "gcp-tls-roots", "ring-aead-encryption"]
 
 [[example]]
 name = "aws_secret_manager_vault"
@@ -86,7 +102,7 @@ required-features = ["aws-secretmanager", "ring-aead-encryption"]
 [[example]]
 name = "kms_gcp_secret_manager_vault"
 path = "examples/kms_gcp_secret_manager_vault.rs"
-required-features = ["gcp-secretmanager", "gcp-kms-encryption"]
+required-features = ["gcp-secretmanager", "gcp-tls-roots", "gcp-kms-encryption"]
 
 [[example]]
 name = "kms_aws_secret_manager_vault"

--- a/secret-vault/src/errors.rs
+++ b/secret-vault/src/errors.rs
@@ -205,7 +205,7 @@ impl Display for SecretsSourceError {
 
 impl std::error::Error for SecretsSourceError {}
 
-#[cfg(feature = "gcp")]
+#[cfg(feature = "gcp-base")]
 impl From<gcloud_sdk::error::Error> for SecretVaultError {
     fn from(e: gcloud_sdk::error::Error) -> Self {
         SecretVaultError::SecretsSourceError(
@@ -218,7 +218,7 @@ impl From<gcloud_sdk::error::Error> for SecretVaultError {
     }
 }
 
-#[cfg(feature = "gcp")]
+#[cfg(feature = "gcp-base")]
 impl From<gcloud_sdk::tonic::Status> for SecretVaultError {
     fn from(status: gcloud_sdk::tonic::Status) -> Self {
         match status.code() {

--- a/secret-vault/src/gcp/mod.rs
+++ b/secret-vault/src/gcp/mod.rs
@@ -1,9 +1,9 @@
-#[cfg(feature = "gcp-secretmanager")]
+#[cfg(feature = "gcp-base")]
 mod gcp_secret_manager_source;
-#[cfg(feature = "gcp-secretmanager")]
+#[cfg(feature = "gcp-base")]
 pub use gcp_secret_manager_source::*;
 
-#[cfg(feature = "gcp-kms-encryption")]
+#[cfg(feature = "gcp-kms")]
 mod gcp_kms_encryption;
-#[cfg(feature = "gcp-kms-encryption")]
+#[cfg(feature = "gcp-kms")]
 pub use gcp_kms_encryption::*;

--- a/secret-vault/src/lib.rs
+++ b/secret-vault/src/lib.rs
@@ -56,6 +56,18 @@
 #![allow(unused_parens, clippy::new_without_default, clippy::needless_update)]
 #![forbid(unsafe_code)]
 
+#[cfg(all(
+    feature = "gcp-base",
+    not(feature = "gcp-tls-roots"),
+    not(feature = "gcp-tls-webpki")
+))]
+compile_error!(
+    "You must enable either \"gcp-tls-roots\" or \"gcp-tls-webpki\" when using GCP features"
+);
+
+#[cfg(all(feature = "gcp-tls-roots", feature = "gcp-tls-webpki"))]
+compile_error!("You cannot enable both \"gcp-tls-roots\" and \"gcp-tls-webpki\" at the same time");
+
 mod encryption;
 pub use encryption::*;
 
@@ -74,7 +86,7 @@ pub use common_types::*;
 #[cfg(feature = "ring-aead-encryption")]
 pub mod ring_encryption;
 
-#[cfg(feature = "gcp")]
+#[cfg(feature = "gcp-base")]
 pub mod gcp;
 
 #[cfg(feature = "aws")]
@@ -103,5 +115,5 @@ pub use vault_auto_refresher::*;
 mod multiple_sources;
 pub use multiple_sources::*;
 
-#[cfg(feature = "gcp")]
+#[cfg(feature = "gcp-base")]
 mod prost_chrono;


### PR DESCRIPTION
Add the possibility to choose between tls-root and tls-webpki-roots for the dependency gcloud-sdk.
Just try to do the same thing as for your other GCP crate like firestore-rs.
A little more tricky here with several backend (GCP and AWS).

There is the alternative to do something like :
```toml
[features]
gcp-base = ["gcloud-sdk"]

# TLS variants - user can choose one
gcp-tls-roots = ["gcp-base", "gcloud-sdk/tls-roots"]
gcp-tls-webpki = ["gcp-base", "gcloud-sdk/tls-webpki-roots"]

gcp-secretmanager = ["gcp-base", "gcloud-sdk/google-cloud-secretmanager-v1", "ring-aead-encryption"]
gcp-kms = ["gcp-base", "kms", "gcloud-sdk/google-cloud-kms-v1", "kms-aead/gcp-kms-encryption", "ring-aead-encryption"]

gcp = ["gcp-base", "gcp-tls-roots"]  # Default to tls-roots for backward compatibility
```

But this introduce the need to check if one tls options has been chosen or if the two options are wrongly selected with something like:
```rust
#[cfg(all(
    feature = "gcp-base",
    not(feature = "gcp-tls-roots"),
    not(feature = "gcp-tls-webpki")
))]
compile_error!("You must enable either \"gcp-tls-roots\" or \"gcp-tls-webpki\" when using GCP features");

#[cfg(all(
    feature = "gcp-tls-roots",
    feature = "gcp-tls-webpki"
))]
compile_error!("You cannot enable both \"gcp-tls-roots\" and \"gcp-tls-webpki\" at the same time");
```

If you prefer this way I can make the changes :)